### PR TITLE
Don't hide the existing stack trace of the original error message if exists.

### DIFF
--- a/src/retry.decorator.test.ts
+++ b/src/retry.decorator.test.ts
@@ -53,6 +53,27 @@ class TestClass {
   }
 }
 
+describe('Capture original error data Test', () => {
+  test('exceed max retry', async () => {
+    const testClass = new TestClass();
+
+    const originalStackTrace = 'foo';
+    const errorMsg = 'rejected';
+
+    const unexpectedError = new Error(errorMsg);
+    unexpectedError.stack = originalStackTrace;
+
+    const calledSpy = jest.spyOn(testClass, 'called');
+
+    calledSpy.mockRejectedValue(unexpectedError);
+    try {
+      await testClass.testMethod();
+    } catch (e) {
+      expect(e.stack).toEqual(originalStackTrace);
+    }
+  });
+});
+
 
 describe('Retry Test', () => {
   let testClass: TestClass;

--- a/src/retry.decorator.ts
+++ b/src/retry.decorator.ts
@@ -41,7 +41,13 @@ export function Retryable(options: RetryOptions): DecoratorFunction {
     } catch (e) {
       if (--maxAttempts < 0) {
         e?.message && console.error(e.message);
-        throw new MaxAttemptsError(e?.message);
+        const maxAttemptsErrorInstance = new  MaxAttemptsError(e?.message);
+        // Add the existing error stack if present
+        if(e?.stack) {
+          maxAttemptsErrorInstance.stack = e.stack;
+        }
+
+        throw maxAttemptsErrorInstance;
       }
       if (!canRetry(e)) {
         throw e;


### PR DESCRIPTION
Currently we are creating a new Error to raise if we hit the max attempts.

This removes the original errors stack trace: 

```
    Failed for 'test' for 2 times. Original Error: Failed for 'test' for 2 times. Original Error: error

      at APP.<anonymous> (node_modules/typescript-retry-decorator/src/retry.decorator.ts:44:15)
          at Generator.throw (<anonymous>)
      at rejected (node_modules/typescript-retry-decorator/dist/retry.decorator.js:6:65)
```

Instead, we should include the original stack trace if exists.