### PR TITLE
Add option to not log through console

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Import and use it. Retry for `Promise` is supported as long as the `runtime` has
 | exponentialOption | object                | No        | { maxInterval: 2000,    multiplier: 2 } | This is for the `ExponentialBackOffPolicy` <br/> The max interval each wait and the multiplier for the `backOff`. |
 | doRetry           | (e: any) => boolean   | No        | -                                       | Function with error parameter to decide if repetition is necessary.                                               |
 | value             | Error/Exception class | No        | [ ]                                     | An array of Exception types that are retryable.                                                                   |
+| useConsoleLogger  | boolean               | No        | true                                    | Print errors on console.                                                                                           |
 
 ### Example
 ```typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-retry-decorator",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-retry-decorator",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.1",

--- a/src/retry.decorator.test.ts
+++ b/src/retry.decorator.test.ts
@@ -48,6 +48,12 @@ class TestClass {
     await this.called();
   }
 
+  @Retryable({ maxAttempts: 2, useConsoleLogger: false })
+  async noLog(): Promise<void> {
+    console.log(`test method is called for ${++this.count} time`);
+    await this.called();
+  }
+
   async called(): Promise<string> {
     return 'from real implementation';
   }
@@ -152,6 +158,16 @@ describe('Retry Test', () => {
       await testClass.exponentialBackOffRetry();
     } catch (e) {}
     expect(calledSpy).toHaveBeenCalledTimes(4);
+  });
+
+  test('no log', async () => {
+    const calledSpy = jest.spyOn(testClass, 'called');
+    const errorSpy = jest.spyOn(console, 'error');
+    calledSpy.mockRejectedValueOnce(new Error('rejected'));
+    calledSpy.mockResolvedValueOnce('fulfilled');
+    await testClass.testMethod();
+    expect(calledSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/retry.decorator.ts
+++ b/src/retry.decorator.ts
@@ -40,7 +40,7 @@ export function Retryable(options: RetryOptions): DecoratorFunction {
       return await fn.apply(this, args);
     } catch (e) {
       if (--maxAttempts < 0) {
-        e?.message && console.error(e.message);
+        (typeof options.useConsoleLogger !== 'boolean' || options.useConsoleLogger) && e?.message && console.error(e.message);
         const maxAttemptsErrorInstance = new  MaxAttemptsError(e?.message);
         // Add the existing error stack if present
         if(e?.stack) {
@@ -96,6 +96,7 @@ export interface RetryOptions {
   doRetry?: (e: any) => boolean;
   value?: ErrorConstructor[];
   exponentialOption?: { maxInterval: number; multiplier: number };
+  useConsoleLogger?: boolean;
 }
 
 export enum BackOffPolicy {


### PR DESCRIPTION
Add an option to not log to console.
It is normal to use an external library for logging, we might not want to log using the console.
The default behavior has been set to keep logging when the option is not present for backward compatibility 