### PR TITLE
fix: Added nullish checks and fixed sleep issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-retry-decorator",
-  "version": "2.4.1",
+  "version": "2.4.0",
   "description": "A simple retry decorator for typescript with no dependency.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-retry-decorator",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A simple retry decorator for typescript with no dependency.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/retry.decorator.ts
+++ b/src/retry.decorator.ts
@@ -53,9 +53,18 @@ export function Retryable(options: RetryOptions): DecoratorFunction {
       if (!canRetry(e)) {
         throw e;
       }
-      backOff && (await sleep(applyBackoffStrategy(backOff)));
-      if (options.backOffPolicy === BackOffPolicy.ExponentialBackOffPolicy) {
-        backOff = Math.min(backOff * options.exponentialOption.multiplier, options.exponentialOption.maxInterval);
+      if (backOff) {
+        await sleep(applyBackoffStrategy(backOff));
+
+        if (
+          options.exponentialOption &&
+          options.backOffPolicy === BackOffPolicy.ExponentialBackOffPolicy
+        ) {
+          backOff = Math.min(
+            backOff * options.exponentialOption.multiplier,
+            options.exponentialOption.maxInterval
+          );
+        }
       }
       return retryAsync.apply(this, [fn, args, maxAttempts, backOff]);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "strictNullChecks": true,
     "target": "ES2015",
     "noImplicitAny": true,
     "declaration": true,


### PR DESCRIPTION
Added Strict Null check validation in TSConfig -> [info](https://www.typescriptlang.org/tsconfig#strictNullChecks)

This found an issue where `backoff` or `exponentialOption` could be undefined in the `Math.min` evaluation.

Add a Jest Spy for the sleep to verify this and added mocking to `sleep` which decreased UT time from 15s to 0.8 s :)