### PR TITLE
ci: publish to npm via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Install Node.js 
@@ -43,5 +46,3 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Switch npm publishing to use npm Trusted Publishing (OIDC) so we no longer need an NPM token secret.\n\nChanges:\n- Add job permissions: id-token: write, contents: read\n- Remove NODE_AUTH_TOKEN env from publish step\n\nFixes #41